### PR TITLE
Replace double spaces in output

### DIFF
--- a/n2w/n2w.py
+++ b/n2w/n2w.py
@@ -37,4 +37,4 @@ class N2w(Convert):
 
                 if int(number) < 1:
                     break
-            return "{} {}".format(prefix, result).strip()
+            return "{} {}".format(prefix, result).strip().replace("  ", " ")


### PR DESCRIPTION
There are sometimes some **double spaces** in the output made by `convert()`.


Can be fixed by simply doing a `.replace("  ", " ")` at the end, I think.